### PR TITLE
Remove deprecated AsyncJobHtmlPyEditor configuration and adjust check…

### DIFF
--- a/oxt/Addons.xcu
+++ b/oxt/Addons.xcu
@@ -265,17 +265,6 @@
                      <value>_self</value>
                   </prop>
                </node>
-               <node oor:name="m017" oor:op="replace">
-                  <prop oor:name="URL" oor:type="xs:string">
-                     <value>vnd.sun.star.job:service=___lo_identifier___.AsyncJobHtmlPyEditor</value>
-                  </prop>
-                  <prop oor:name="Title" oor:type="xs:string">
-                     <value>Web Veiw</value>
-                  </prop>
-                  <prop oor:name="Target" oor:type="xs:string">
-                     <value>_self</value>
-                  </prop>
-               </node>
             </node>
          </node>
       </node>

--- a/oxt/dialogs/lp_settings.xdl
+++ b/oxt/dialogs/lp_settings.xdl
@@ -9,6 +9,6 @@
             dlg:font-stylename="Book" dlg:font-family="modern" />
     </dlg:styles>
     <dlg:bulletinboard>
-        <dlg:checkbox dlg:control-implementation="stardiv.one.form.component.CheckBox" dlg:id="chkExperimental" dlg:tab-index="0" dlg:left="18" dlg:top="15" dlg:width="140" dlg:height="9" dlg:value="strExperimental" />
+        <dlg:checkbox dlg:control-implementation="stardiv.one.form.component.CheckBox" dlg:id="chkExperimental" dlg:tab-index="0" dlg:left="18" dlg:top="15" dlg:width="180" dlg:height="9" dlg:value="strExperimental" />
     </dlg:bulletinboard>
 </dlg:window>


### PR DESCRIPTION
This pull request includes changes to remove an obsolete node from the `Addons.xcu` file and adjust the width of a checkbox in the `lp_settings.xdl` file.

Changes to `Addons.xcu`:

* Removed an obsolete node that contained properties for a URL, Title, and Target.

Changes to `lp_settings.xdl`:

* Adjusted the width of the `chkExperimental` checkbox from 140 to 180.…box width in settings dialog